### PR TITLE
docs: add MIT license badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build](https://github.com/rwv/browser-web-worker/actions/workflows/build.yml/badge.svg)](https://github.com/rwv/browser-web-worker/actions/workflows/build.yml)
 [![NPM Version](https://img.shields.io/npm/v/browser-web-worker)](https://www.npmjs.com/package/browser-web-worker)
+[![GitHub License](https://img.shields.io/github/license/rwv/browser-web-worker)](https://github.com/rwv/browser-web-worker/blob/main/LICENSE)
 
 Run Web Workers in Node.js using a real Chrome browser via Puppeteer.
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a badge to display the GitHub license for the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5): Added a GitHub license badge to the README file.