### PR TITLE
perf: exclude `src` and `*.test.ts` from published pkg

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,4 +6,7 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    ignores: ["lib/**"],
+  },
 );

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   },
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "types": ["node"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib", "**/*.test.ts"]
 }


### PR DESCRIPTION
This pull request includes updates to the ESLint configuration and the `package.json` file to improve the project's setup and dependency management. The most important changes include adding an ignore pattern to the ESLint configuration and adjusting the list of files included in the package.

Improvements to ESLint configuration:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R9-R11): Added an ignore pattern to exclude the `lib` directory from ESLint checks.

Updates to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R37): Removed the `src` directory from the list of files included in the package.